### PR TITLE
CRM-21071 event location mail broken

### DIFF
--- a/CRM/Core/BAO/Block.php
+++ b/CRM/Core/BAO/Block.php
@@ -302,6 +302,11 @@ class CRM_Core_BAO_Block {
               $valueId = TRUE;
             }
           }
+          //CRM-21071
+          elseif ($blockName == 'email') {
+              //do nothing, prevent by passing $blockName=='email'
+              //$valueId = TRUE;
+          }
           else {
             $valueId = TRUE;
           }


### PR DESCRIPTION
Overview
----------------------------------------
solved event location mail broken
https://issues.civicrm.org/jira/browse/CRM-21071

Before
----------------------------------------
In case of updating event location. If second email was entered, the first email disapeared after click save.

After
----------------------------------------
solved 


